### PR TITLE
Replace legacy esoleaderboards api calls with new calls

### DIFF
--- a/modules/leaderboards.js
+++ b/modules/leaderboards.js
@@ -61,7 +61,7 @@ if (options.options == "!help"){
 	
 	name = encodeURI(nameorg)
 	
-    var baserURL = "https://www.esoleaderboards.com/api/api.php?callType=getScoreBy"+characc+"Name&megaserver="
+    var baserURL = "https://www.esoleaderboards.com/api/score/character?megaserver="
 
     var lbAPI = [];
     var triallist = [];

--- a/modules/trials.js
+++ b/modules/trials.js
@@ -27,7 +27,7 @@ if (options.options.includes("-help")){
 
 }else{
 	// set up the URL based on megaserver
-    var baserURL = "https://www.esoleaderboards.com/api/api.php?callType=getWeeklyTrial&megaserver="
+    var baserURL = "https://www.esoleaderboards.com/api/weekly?megaserver="
     var servers = []
     if (options.megaservers.length == 0 || options.megaservers.includes("NA")){
     	servers.push("NA")


### PR DESCRIPTION
Since I completely rewrote the core of the system, the old api has been legacy for a while and is now deprecated. It will be removed in March. I replaced the old calls with the new ones.

I see I can merge, but I'll let you do that.