### PR TITLE
Add timezone conversion command

### DIFF
--- a/foxbot-dev.js
+++ b/foxbot-dev.js
@@ -29,6 +29,7 @@ const ttc = require('./modules/ttc.sql.js');
 const configure = require('./modules/settings.sql.js');
 const guildUpdate = require('./modules/guild.sql.js');
 const easteregg = require('./modules/easteregg.js');
+const time = require('./modules/time.js');
 //const test = require('./modules/test.js');
 
 // helper functions
@@ -87,6 +88,7 @@ bot.on("message", (msg) => {
    		if (settings[s].setting == "-megaserver" && options.megaservers.length==0 && settings[s].value != 0) options.megaservers.push(Object.keys(nh.listServers())[settings[s].value-1].toUpperCase())
    		if (settings[s].setting == "-replytype" && settings[s].value == 1 && options.command != "!config" && options.command != "!poll") options["rechannel"] = "redirectDM"
    		if (settings[s].setting == "-replytype" && settings[s].value == 2 && options.command != "!config" && options.command != "!poll") {options["rechannel"] = "redirectChannel"; options["rechannelid"] = settings[s].sap}
+   		if (settings[s].setting == "-timezone") options["timezone"] = settings[s].value
    	}
    	
    	//console.log("blacklist: "+blacklistChannel.join(","))
@@ -120,6 +122,7 @@ bot.on("message", (msg) => {
 		"!price"		: function(){ttc(bot, msg, options, Discord);}, 
 		"!christmas"	: function(){easteregg(bot, msg, options, "christmas", Discord);}, 
 		"!secretshanta"	: function(){easteregg(bot, msg, options, "christmas", Discord);}, 
+        "!time" 		: function () { time(bot, msg, options, Discord); },
 //		"!test"			: function(){test(bot, msg, options, Discord);}, 
 		
 		//v2 preparation

--- a/helper/arguments.js
+++ b/helper/arguments.js
@@ -86,7 +86,8 @@ exports.argumentSlicer = function(msg, mysql, callback){ // add required / optio
 		"date"			: [],
 		"range"			: [],
 		"others"		: [],
-		"slice_info"	: []
+		"slice_info"	: [],
+        "timezone"		: []
 	}
 	
 	if (msg.guild){

--- a/helper/timezone.js
+++ b/helper/timezone.js
@@ -1,0 +1,19 @@
+const moment = require('moment-timezone');
+
+exports.searchZone = function(zone) {
+    var matches = [];
+    var exact = '';
+    if (zone.length >= 3)
+        moment.tz.names().forEach(function (val) {
+            if (val.toLowerCase() == zone.toLowerCase())
+                exact = val;
+
+            if (val.toLowerCase().indexOf(zone.toLowerCase()) >= 0)
+                matches.push(val);
+        });
+
+    if (exact.length > 1)
+        matches = [exact];
+
+    return matches;
+}

--- a/modules/time.js
+++ b/modules/time.js
@@ -1,0 +1,59 @@
+const moment = require('moment-timezone');
+require('datejs');
+const mh = require("../helper/messages.js")
+const zone = require("../helper/timezone.js");
+
+
+module.exports = (bot, msg, options, Discord) => {
+    var embed = mh.prepare(Discord)
+
+    if (options.options == "-help" || options.others.length == 0) {
+        embed.setTitle("Options for " + options.command)
+        //embed.addField(options.command, "Shows timezone conversions")
+        embed.addField(options.command + " EST", "Will show the current time for US EST")
+        embed.addField(options.command + " 6am EST in UTC", "Converts a time from EST to UTC")
+    } else {
+        var dest = zone.searchZone(options.others.pop());
+
+        if (dest.length != 1)
+            return; // TODO: Error
+
+        if (options.others.length == 0) {
+            // Single conversion
+            let tz = moment().tz(dest[0]);
+            embed.addField("Time in " + tz.zoneName(), "It is currently " + tz.format('h:mm a z'));
+        }
+        else {
+            var query = options.others.join(" ");
+            var src = zone.searchZone(options.others.pop());
+            if (src.length == 0 && options.others.length > 0)
+                src = zone.searchZone(options.others.pop());    // Assume that the word was a 'joiner' (ie, 'to' 'in' etc)
+
+            if (src.length == 0 && options.timezone.length > 0) {
+                options.others = [query];
+                src = dest;
+                dest = [options.timezone];
+            }
+
+            // Could probably do other smarts here too, eg detect a 'hh:mmZ-00:00' or equivalent
+
+            if (src.length != 1) {
+                // TODO: Error
+                return;
+            }
+
+            query = options.others.join(" ");
+            var parsed = Date.parse(query);
+            if (parsed != null) {
+                var tz = moment.tz(parsed.toString("yyyy-MM-ddTHH:mm:ss"), src[0]);
+                embed.addField("Conversion to " + dest[0], tz.format("ddd h:mm a z") + " converts to " + tz.tz(dest[0]).format("ddd h:mm a z"));
+            }
+            else
+                return;
+        }
+
+    }
+
+    mh.send(msg, embed, options)
+
+};

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bluebird": "3.5.0",
     "cheerio": "0.22.0",
     "csvtojson": "^1.1.6",
+    "datejs": "^1.0.0-rc3",
     "discord.js": "^11.1.0",
     "extract-zip": "^1.6.5",
     "file-exists": "^4.0.0",


### PR DESCRIPTION
As from #3, now with resync'd fork.

The one thing I miss from my own discord bot since I retired it.

!time est
-> returns current time EST

!time 4am est in utc
!time sunday 4am us/eastern in sydney
-> converts between timezones

Adds a new NPM dependency of DateJS.

Also ties into the config system
!config -timezone adelaide
!time 4am est
-> converts from specified timezone to guild default timezone

Code is a bit hacky in place, and doesn't really have suitable error responses (errs to silent failure) since I'm still trying to understand how the settings work, etc.